### PR TITLE
Resolve [Bug]/#24

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+title: "[Bug]: "
+description: "Use this template if you're running into bugs or other issues"
+labels:
+  - T-bug
+  - S-needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        ## Instructions
+
+
+        This is a template for the issue you are about to open! It will help you
+        provide the information necessary to complete your **bug report**.
+        Before you open an issue, ensure you've completed every step on the
+        checklist below.
+
+
+        - Have you used the [search
+        tool](https://github.com/Awakened-Redstone/Subathon/issues) to find
+        similar issues? If you find one that looks like what you are getting,
+        consider contributing additional information to it instead. Make sure
+        you are not opening a duplicate.
+
+        - Are you using the latest version of the mod? If not, try updating to
+        see if it resolves your issue.
+
+
+        All good? Then continue to fill the issue by providing the following
+        information about it:
+  - type: input
+    id: version
+    attributes:
+      label: Version information
+      description: >-
+        Please provide the exact version of the mod you are using. Every part of
+        the version is important! If you do not know what version you are using,
+        look at the file name in your `mods` folder.
+      placeholder: 'Example: 1.0.4-beta.2'
+    validations:
+      required: true
+  - type: dropdown
+    id: version_type
+    attributes:
+      label: Version type
+      description: What version of AutoWhitelist are you running?
+      options:
+        - Lite
+        #- Full
+      validations:
+        required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: 'Example: The Piston should extend.'
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What did actually happen?
+      placeholder: 'Example: The Piston does not extend.'
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Reproduction Steps
+      description: >-
+        Provide information on how to reproduce this bug. You can either
+        fill this section in like the example below or do something else just
+        make sure your instructions are minimal and clear, as other people will
+        need to be able to replicate your issue.
+      placeholder: |
+        Example:
+        1. Place a Redstone Lamp in front of a Redstone Repeater
+        2. Use a Lever to activate the Redstone Repeater
+        3. Nothing happens
+    validations:
+      required: true
+  - type: input
+    id: java
+    attributes:
+      label: Java version
+      placeholder: 'Example: Java 17'
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: >-
+        Provide a list of any other mods you are using, along with their
+        respective versions. If you have any screenshots, videos, or other
+        information that you feel is necessary to explain the issue, feel free
+        to attach them here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,16 +40,6 @@ body:
       placeholder: 'Example: 1.0.4-beta.2'
     validations:
       required: true
-  - type: dropdown
-    id: version_type
-    attributes:
-      label: Version type
-      description: What version of AutoWhitelist are you running?
-      options:
-        - Lite
-        - Full
-    validations:
-      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,8 +48,8 @@ body:
       options:
         - Lite
         #- Full
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
       description: What version of AutoWhitelist are you running?
       options:
         - Lite
-        #- Full
+        - Full
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,12 +32,23 @@ body:
   - type: input
     id: version
     attributes:
-      label: Version information
+      label: Mod version
       description: >-
         Please provide the exact version of the mod you are using. Every part of
         the version is important! If you do not know what version you are using,
         look at the file name in your `mods` folder.
       placeholder: 'Example: 1.0.4-beta.2'
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Minecraft version
+      description: >-
+        Please provide the exact version of the mod you are using. Every part of
+        the version is important! If you do not know what version you are using,
+        look at the file name in your `mods` folder.
+      placeholder: '1.20.2'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,88 @@
+name: Crash report
+title: "[Crash]: "
+description: Use this template if your game is crashing or failing to start correctly
+labels:
+  - T-crash
+  - S-needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        ## Instructions (read me before you open an issue!)
+
+
+        This is a template for the issue you are about to open! It will help you
+        provide the information necessary to complete your **crash report**.
+        Before you open an issue, ensure you've completed every step on the
+        checklist below.
+
+
+        - Have you used the [search
+        tool](https://github.com/Awakened-Redstone/Subathon/issues) to find
+        similar issues? If you find one that looks like what you are getting,
+        consider contributing additional information to it instead. Make sure
+        you are not opening a duplicate.
+
+        - Are you using the latest version of the mod? If not, try updating to
+        see if it resolves your issue.
+
+
+        All good? Then continue to fill the issue by providing the following
+        information about it:
+  - type: input
+    id: version
+    attributes:
+      label: Version information
+      description: >-
+        Please provide the exact version of the mod you are using. Every part of
+        the version is important! If you do not know what version you are using,
+        look at the file name in your `mods` folder.
+      placeholder: 'Example: 1.0.0-beta.2'
+    validations:
+      required: true
+  - type: dropdown
+    id: version_type
+    attributes:
+      label: Version type
+      description: What version of AutoWhitelist are you running?
+      options:
+        - Lite
+        #- Full
+      validations:
+        required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Reproduction Steps
+      description: >-
+        Provide information on how to reproduce this game crash. You can either
+        fill this section in like the example below or do something else just
+        make sure your instructions are minimal and clear, as other people will
+        need to be able to replicate your issue.
+      placeholder: |
+        Example:
+        1. Place a Redstone Lamp in front of a Redstone Repeater
+        2. Use a Lever to activate the Redstone Repeater
+        3. The game crashes
+    validations:
+      required: true
+  - type: textarea
+    id: report
+    attributes:
+      label: Crash Report file
+      description: >-
+        Upload your crash report file as an attachment to this issue (drag-and-drop) or to a service such as GitHub
+        Gist (paste a link) and replace this section. This information is critical in resolving your issue!
+        
+        Messages like "Exit code 0" from your launcher are not what you're looking for. If your launcher does not
+        provide a button to view the most recent crash report, check your game's `crash-reports` folder for the most recent
+        crash report file.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: >-
+        Provide any additional information or context which may be relevant to
+        the issue. If you have none to add,  you can leave this section blank.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -40,16 +40,6 @@ body:
       placeholder: 'Example: 1.0.0-beta.2'
     validations:
       required: true
-  - type: dropdown
-    id: version_type
-    attributes:
-      label: Version type
-      description: What version of AutoWhitelist are you running?
-      options:
-        - Lite
-        - Full
-    validations:
-      required: true
   - type: textarea
     id: repro-steps
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -47,7 +47,7 @@ body:
       description: What version of AutoWhitelist are you running?
       options:
         - Lite
-        #- Full
+        - Full
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -40,6 +40,17 @@ body:
       placeholder: 'Example: 1.0.0-beta.2'
     validations:
       required: true
+  - type: input
+    id: version
+    attributes:
+      label: Minecraft version
+      description: >-
+        Please provide the exact version of the mod you are using. Every part of
+        the version is important! If you do not know what version you are using,
+        look at the file name in your `mods` folder.
+      placeholder: '1.20.2'
+    validations:
+      required: true
   - type: textarea
     id: repro-steps
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -48,8 +48,8 @@ body:
       options:
         - Lite
         #- Full
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: repro-steps
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -5,6 +5,16 @@ labels:
   - T-enhancement
   - T-documentation
 body:
+  - type: dropdown
+    id: version_type
+    attributes:
+      label: Version type
+      description: What version of AutoWhitelist are you running?
+      options:
+        - Lite
+        - Full
+    validations:
+      required: true
   - type: textarea
     id: target
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -5,16 +5,6 @@ labels:
   - T-enhancement
   - T-documentation
 body:
-  - type: dropdown
-    id: version_type
-    attributes:
-      label: Version type
-      description: What version of AutoWhitelist are you running?
-      options:
-        - Lite
-        - Full
-    validations:
-      required: true
   - type: textarea
     id: target
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,31 @@
+name: Documentation
+description: Issues and suggestions for the documentation
+title: "[Documentation]: "
+labels:
+  - T-enhancement
+  - T-documentation
+body:
+  - type: textarea
+    id: target
+    attributes:
+      label: What on the documentation is being suggested to be changed
+      description: >-
+        A simple description of the area or page to be changed/added
+      placeholder: 'Tutorial section'
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the change
+      description: >-
+        A clear and concise description of the documentation change.
+      placeholder: 'Missing information for [...]'
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "[New feature]: "
+labels:
+  - T-enhancement
+  - T-documentation
+  - S-needs-triage
+body:
+  - type: textarea
+    id: is_problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: >-
+        A clear and concise description of what the problem is.
+      placeholder: 'I''m always frustrated when [...]'
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Describe the solution you'd like
+      description: >-
+        A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: >-
+        A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,19 +3,7 @@ description: Suggest an idea for this project
 title: "[New feature]: "
 labels:
   - T-enhancement
-  - T-documentation
-  - S-needs-triage
 body:
-  - type: dropdown
-    id: version_type
-    attributes:
-      label: Version type
-      description: What version of AutoWhitelist are you running?
-      options:
-        - Lite
-        - Full
-    validations:
-      required: true
   - type: textarea
     id: is_problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,6 +6,16 @@ labels:
   - T-documentation
   - S-needs-triage
 body:
+  - type: dropdown
+    id: version_type
+    attributes:
+      label: Version type
+      description: What version of AutoWhitelist are you running?
+      options:
+        - Lite
+        - Full
+    validations:
+      required: true
   - type: textarea
     id: is_problem
     attributes:

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ $RECYCLE.BIN/
 
 .gradle
 build/
+bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/main/java/com/awakenedredstone/autowhitelist/discord/BotHelper.java
+++ b/src/main/java/com/awakenedredstone/autowhitelist/discord/BotHelper.java
@@ -1,6 +1,10 @@
 package com.awakenedredstone.autowhitelist.discord;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
@@ -10,7 +14,8 @@ import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.minecraft.text.Text;
 
-import java.awt.*;
+import java.awt.Color;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class BotHelper extends Bot {
@@ -72,6 +77,12 @@ public class BotHelper extends Bot {
     public static void sendTempSimpleMessage(MessageChannel channel, Text message, int seconds) {
         MessageCreateAction messageAction = channel.sendMessage(message.getString());
         messageAction.queue(m -> m.delete().queueAfter(seconds, TimeUnit.SECONDS));
+    }
+
+    public static List<Role> getRolesForMember(Member member) {
+        List<Role> roles = member.getRoles();
+        roles.add(member.getGuild().getPublicRole());
+        return roles;
     }
 
     public enum MessageType {

--- a/src/main/java/com/awakenedredstone/autowhitelist/discord/DiscordDataProcessor.java
+++ b/src/main/java/com/awakenedredstone/autowhitelist/discord/DiscordDataProcessor.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.awakenedredstone.autowhitelist.discord.Bot.guild;
+import static com.awakenedredstone.autowhitelist.discord.BotHelper.getRolesForMember;
 import static com.awakenedredstone.autowhitelist.util.Debugger.analyzeTimings;
 
 public class DiscordDataProcessor implements Runnable {
@@ -30,7 +31,7 @@ public class DiscordDataProcessor implements Runnable {
 
             List<Member> members = guild.findMembers(v -> {
                 if (v.getUser().isBot()) return false;
-                return hasRole(v.getRoles());
+                return hasRole(getRolesForMember(v));
             }).get();
             List<String> memberIds = members.stream().map(ISnowflake::getId).toList();
 
@@ -47,7 +48,7 @@ public class DiscordDataProcessor implements Runnable {
             }
 
             for (Member member : members) {
-                String role = getTopRole(member.getRoles()).get();
+                String role = getTopRole(getRolesForMember(member)).get();
                 List<ExtendedGameProfile> profiles = whitelist.getProfilesFromDiscordId(member.getId());
                 if (profiles.isEmpty()) continue;
                 if (profiles.size() > 1) {

--- a/src/main/java/com/awakenedredstone/autowhitelist/discord/commands/RegisterCommand.java
+++ b/src/main/java/com/awakenedredstone/autowhitelist/discord/commands/RegisterCommand.java
@@ -51,10 +51,8 @@ public class RegisterCommand {
                 Text.translatable("command.feedback.received.message"), 10);
 
             String id = member.getId();
-            List<Role> roles = member.getRoles();
-            roles.add(member.getGuild().getPublicRole());
 
-            boolean accepted = !Collections.disjoint(roles.stream().map(Role::getId).toList(), new ArrayList<>(AutoWhitelist.whitelistDataMap.keySet()));
+            boolean accepted = !Collections.disjoint(getRolesForMember(member).stream().map(Role::getId).toList(), new ArrayList<>(whitelistDataMap.keySet()));
             if (accepted) {
                 MinecraftServer server = AutoWhitelist.server;
                 ExtendedWhitelist whitelist = (ExtendedWhitelist) server.getPlayerManager().getWhitelist();

--- a/src/main/java/com/awakenedredstone/autowhitelist/discord/commands/RegisterCommand.java
+++ b/src/main/java/com/awakenedredstone/autowhitelist/discord/commands/RegisterCommand.java
@@ -52,6 +52,7 @@ public class RegisterCommand {
 
             String id = member.getId();
             List<Role> roles = member.getRoles();
+            roles.add(member.getGuild().getPublicRole());
 
             boolean accepted = !Collections.disjoint(roles.stream().map(Role::getId).toList(), new ArrayList<>(AutoWhitelist.whitelistDataMap.keySet()));
             if (accepted) {

--- a/src/main/java/com/awakenedredstone/autowhitelist/discord/events/CoreEvents.java
+++ b/src/main/java/com/awakenedredstone/autowhitelist/discord/events/CoreEvents.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.awakenedredstone.autowhitelist.discord.Bot.*;
+import static com.awakenedredstone.autowhitelist.discord.BotHelper.getRolesForMember;
 import static com.awakenedredstone.autowhitelist.util.Debugger.analyzeTimings;
 
 public class CoreEvents {
@@ -89,7 +90,8 @@ public class CoreEvents {
                 return;
             }
 
-            if (roleOptional.isEmpty()) {
+            List<String> validRoles = getRolesForMember(member).stream().map(Role::getId).filter(whitelistDataMap::containsKey).toList();
+            if (validRoles.isEmpty()) {
                 ExtendedGameProfile profile = profiles.get(0);
                 AutoWhitelist.removePlayer(profile);
                 return;


### PR DESCRIPTION
Resolves #24 

Reopening this using the newly-renamed fork branch version!

---

@Awakened-Redstone @kaydenvg
When executing the whitelist register command in Discord, we take the member's guild's getPublicRole() (which isn't returned in the list from getRoles() because it is documented as implicit):

The @everyone role; synonymous with the guild's ID.

and add it explicitly to the roles we're checking on the member.

This allows users to configure the mod using their guild's @everyone role, and have it behave as expected.